### PR TITLE
Fix script for new Airtable API docs page

### DIFF
--- a/convertAirtableToPostgresqlSchema.js
+++ b/convertAirtableToPostgresqlSchema.js
@@ -2,6 +2,8 @@
 // copy and paste the script below into the devTools console
 // output will generate a postgresql-like schema csv
 
+const application = initData.application;
+
 let baseName = application.name;
 let tableMap = [];
 let rows = [];


### PR DESCRIPTION
The application data is now in a global object called initData. Otherwise, the script all still works.